### PR TITLE
Fix typo in text for Lesson 1

### DIFF
--- a/lessons/training/Lesson-1-compile.ipynb
+++ b/lessons/training/Lesson-1-compile.ipynb
@@ -188,7 +188,7 @@
     "\n",
     "The *compile_offline_Noah.sh* and *compile_offline_NoahMP.sh* execute a similar process during compilation, and this process is described in more detail in [How to Build & Run WRF-Hydro in Standalone Mode](https://ral.ucar.edu/projects/wrf_hydro/technical-description-user-guide) and section 2.6 of the [Technical Description](https://ral.ucar.edu/projects/wrf_hydro/technical-description-user-guide). One action that these scripts perform is to source the *configureEnvars.sh* script to specify compile-time options by setting environment variables.\n",
     "\n",
-    "We will now compile the model by executing the *compile_offline_Noah.sh* script and supplying our *configureEnvars.sh* script as the first argument. Additionally, we will pipe the output from the compilation process to a log file because compilation can generate a lot of output."
+    "We will now compile the model by executing the *compile_offline_NoahMP.sh* script and supplying our *configureEnvars.sh* script as the first argument. Additionally, we will pipe the output from the compilation process to a log file because compilation can generate a lot of output."
    ]
   },
   {


### PR DESCRIPTION
Changed compile_offline_Noah.sh -> compile_offline_NoahMP.sh in the text for step 5 in lesson 1.  This was an old typo that @mollymca caught while making some edits for the upcoming training.  

Not a huge deal in that it doesn't impact the functionality of the lessons, but is somewhat confusing and should be fixed before the upcoming CUAHSI training.